### PR TITLE
Fixes for CUDA memory issues

### DIFF
--- a/stylegan2/train.py
+++ b/stylegan2/train.py
@@ -459,7 +459,8 @@ class Trainer:
                 scaled_loss.backward()
         else:
             loss.backward()
-        return loss * (self.world_size or 1)
+        #use loss item?
+        return loss.item() * (self.world_size or 1)
 
     def train(self, iterations, callbacks=None, verbose=True):
         """
@@ -571,7 +572,8 @@ class Trainer:
                         real_labels=real_labels
                     )
                     D_loss += self._backward(loss, self.D_opt)
-                    D_loss += loss
+#                     D_loss += loss
+                    D_loss += loss.item()
 
                 if D_reg:
                     if self.D_reg_interval:
@@ -661,7 +663,9 @@ class Trainer:
                 callback(self.seen)
 
             self.seen += 1
-
+            
+            # clear cache
+            torch.cuda.empty_cache()
             # Handle checkpointing
             if not self.rank and self.checkpoint_dir and self.checkpoint_interval:
                 if self.seen % self.checkpoint_interval == 0:

--- a/stylegan2/train.py
+++ b/stylegan2/train.py
@@ -459,7 +459,7 @@ class Trainer:
                 scaled_loss.backward()
         else:
             loss.backward()
-        #use loss item?
+        #get the scalar only
         return loss.item() * (self.world_size or 1)
 
     def train(self, iterations, callbacks=None, verbose=True):


### PR DESCRIPTION
Hi, apparently, the memory issues during loss.backwards() were due to saving the computation graph for loss for each iteration. I changed some of the losses to return only scalars, and it solved the memory problem I was facing.