### PR TITLE
fixed borken url

### DIFF
--- a/stylegan2/external_models/lpips.py
+++ b/stylegan2/external_models/lpips.py
@@ -34,7 +34,7 @@ import torchvision
 class LPIPS_VGG16(nn.Module):
     _FEATURE_IDX = [0, 4, 9, 16, 23, 30]
     _LINEAR_WEIGHTS_URL = 'https://github.com/richzhang/PerceptualSimilarity' + \
-                          '/blob/master/models/weights/v0.1/vgg.pth?raw=true'
+                          '/blob/master/lpips/weights/v0.1/vgg.pth?raw=true'
 
     def __init__(self, pixel_min=-1, pixel_max=1):
         super(LPIPS_VGG16, self).__init__()


### PR DESCRIPTION
Fixed borken url under lpips module when loading vgg weights.